### PR TITLE
Start agent after database migration

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -149,6 +149,21 @@ app.Use((context, next) =>
     return next();
 });
 
+// Apply database migrations at startup
+try
+{
+    using (var scope = app.Services.CreateScope())
+    {
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        dbContext.Database.Migrate();
+        Console.WriteLine("Database migration completed successfully");
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"An error occurred while migrating the database: {ex.Message}");
+}
+
 // Important: UseRouting must come before UseZenFirewall to ensure we receive all context information
 app.UseRouting();
 
@@ -174,21 +189,6 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-}
-
-// Apply database migrations at startup
-try
-{
-    using (var scope = app.Services.CreateScope())
-    {
-        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        dbContext.Database.Migrate();
-        Console.WriteLine("Database migration completed successfully");
-    }
-}
-catch (Exception ex)
-{
-    Console.WriteLine($"An error occurred while migrating the database: {ex.Message}");
 }
 
 app.Run();


### PR DESCRIPTION
## What changed

Run the Entity Framework database migration before registering and starting the Zen firewall middleware.

## Why

`UseZenFirewall()` starts the agent and its heartbeat schedule immediately. The demo previously started that schedule and then performed its database migration before `app.Run()` made the application available. Under concurrent startup, this allowed startup work to consume part of the agent's initial heartbeat window and included migration-time work in the agent lifecycle.

## Impact

The database schema is still migrated before the application starts accepting requests. The agent now starts after that initialization work has completed, closer to the point where the application becomes available.

## Validation

- Built the application successfully through its Dockerfile.
- Ran the firewall-tester-action ASP.NET Core suite with all 34 test applications concurrently: 34/34 passed, nothing skipped.


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Moved database migration to run before starting Zen firewall.

**🔧 Refactors**
* Wrapped migration with try/catch and logged success and errors.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/151327368?groupId=4948)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->